### PR TITLE
Support fractional radii and the option to check blocks' corners instead of centers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "Generates Pixel Circles",
   "main": "lib/generator.js",
+  "type": "module",
   "directories": {
     "lib": "lib"
   },

--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -55,13 +55,13 @@ export function makeButtonControl(
 export function makeModeControl<E extends Record<string, string>>(
     modeEnum: E,
     selectedMode: string,
-    onAlter: (() => void),
+    onAlter: () => void,
 ): HTMLSelectElement {
     const modeControlElm = document.createElement('select');
 
     for (const item of Object.keys(modeEnum)) {
         const opt = document.createElement('option');
-        opt.innerText = item;
+        opt.innerText = modeEnum[item];
         modeControlElm.appendChild(opt);
 
         if (item == selectedMode) {

--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -7,7 +7,7 @@ This notice may not be removed or altered from any source distribution.
 import { GeneratorInterface2D } from "./Generators/GeneratorInterface2D";
 import { SvgRenderer } from "./Renderers/SvgRenderer";
 import { RendererInterface } from "./Renderers/RendererInterface";
-import { Circle, CircleModes } from "./Generators/Circle";
+import { Circle, CircleModes, FillCheckModes } from "./Generators/Circle";
 import { StateHandler } from "./State";
 
 export interface Control<T extends HTMLElement = HTMLElement> {
@@ -50,6 +50,27 @@ export function makeButtonControl(
 		label,
 		group,
 	};
+}
+
+export function makeModeControl<E extends Record<string, string>>(
+    modeEnum: E,
+    selectedMode: string,
+    onAlter: (() => void),
+): HTMLSelectElement {
+    const modeControlElm = document.createElement('select');
+
+    for (const item of Object.keys(modeEnum)) {
+        const opt = document.createElement('option');
+        opt.innerText = item;
+        modeControlElm.appendChild(opt);
+
+        if (item == selectedMode) {
+            opt.selected = true;
+        }
+    }
+
+    modeControlElm.addEventListener('change', onAlter);
+    return modeControlElm;
 }
 
 export function makeInputControl(
@@ -107,7 +128,8 @@ export class MainController {
 		});
 
 		const circleState = this.stateMananger.get("circle", {
-			mode: CircleModes.thick,
+			circleMode: CircleModes.thick,
+            fillCheckMode: FillCheckModes.center,
 			width: 13,
 			height: 13,
 			force: true,
@@ -118,7 +140,8 @@ export class MainController {
 
 		const circle = new Circle(
 			w, h,
-			circleState.get('mode'),
+			circleState.get('circleMode'),
+            circleState.get('fillCheckMode'),
 			circleState.get('force'),
 		);
 		this.generator = circle;
@@ -126,7 +149,8 @@ export class MainController {
 		this.renderer.changeEmitter.add(() => { this.render(); });
 
 		circle.changeEmitter.add((e) => {
-			circleState.set('mode', e.state.mode);
+			circleState.set('circleMode', e.state.circleMode);
+            circleState.set('fillCheckMode', e.state.fillCheckMode);
 			circleState.set('width', e.state.width);
 			circleState.set('height', e.state.height);
 			circleState.set('force', e.state.force);

--- a/src/Controller.ts
+++ b/src/Controller.ts
@@ -7,7 +7,7 @@ This notice may not be removed or altered from any source distribution.
 import { GeneratorInterface2D } from "./Generators/GeneratorInterface2D";
 import { SvgRenderer } from "./Renderers/SvgRenderer";
 import { RendererInterface } from "./Renderers/RendererInterface";
-import { Circle, CircleModes, FillCheckModes } from "./Generators/Circle";
+import { Circle, CircleCenterModes, CircleModes, FillCheckModes } from "./Generators/Circle";
 import { StateHandler } from "./State";
 
 export interface Control<T extends HTMLElement = HTMLElement> {
@@ -133,6 +133,7 @@ export class MainController {
 			width: 13,
 			height: 13,
 			force: true,
+            circleCenterMode: CircleCenterModes.infer,
 		});
 
 		const w = circleState.get('width');
@@ -143,6 +144,7 @@ export class MainController {
 			circleState.get('circleMode'),
             circleState.get('fillCheckMode'),
 			circleState.get('force'),
+            circleState.get('circleCenterMode'),
 		);
 		this.generator = circle;
 		this.generator.changeEmitter.add(() => { this.render(); });
@@ -154,6 +156,7 @@ export class MainController {
 			circleState.set('width', e.state.width);
 			circleState.set('height', e.state.height);
 			circleState.set('force', e.state.force);
+            circleState.set('circleCenterMode', e.state.circleCenterMode);
 		});
 
 		if (w * h > 200 * 200) {

--- a/src/Generators/Circle.ts
+++ b/src/Generators/Circle.ts
@@ -12,8 +12,8 @@ export enum CircleModes {
 
 export enum FillCheckModes {
     center = 'center',
-    closest = 'closest',
-    furthest = 'furthest',
+    closestCorner = 'closest corner',
+    furthestCorner = 'furthest corner',
 }
 
 function filled(x: number, y: number, radius: number, ratio: number, mode: FillCheckModes): boolean {
@@ -24,11 +24,11 @@ function filled(x: number, y: number, radius: number, ratio: number, mode: FillC
             checkX = x;
             checkY = y;
             break;
-        case FillCheckModes.closest:
+        case FillCheckModes.closestCorner:
             checkX = (x >= 0) ? x - 0.5 : x + 0.5;
             checkY = (y >= 0) ? y - 0.5 : y + 0.5;
             break;
-        case FillCheckModes.furthest:
+        case FillCheckModes.furthestCorner:
             checkX = (x >= 0) ? x + 0.5 : x - 0.5;
             checkY = (y >= 0) ? y + 0.5 : y - 0.5;
             break;
@@ -36,7 +36,7 @@ function filled(x: number, y: number, radius: number, ratio: number, mode: FillC
             throw new NeverError(mode);
         }
     }
-    return distance(x, y, ratio) <= radius;
+    return distance(checkX, checkY, ratio) <= radius * 0.999999999999;
 }
 
 function fatfilled(x: number, y: number, radius: number, ratio: number, mode: FillCheckModes): boolean {
@@ -153,6 +153,7 @@ export class Circle implements GeneratorInterface2D, ControlAwareInterface {
 			this.widthControl,
 			this.heightControl,
 			{ element: this.circleModeControlElm, label: 'border', group: 'Render' },
+            { element: this.fillCheckModeControlElm, label: 'fill check', group: 'Render' },
 		];
 	}
 


### PR DESCRIPTION
Fractional radii seemed straightforward. To make it more useful, I also added an option to force the circle to have an even or odd center (so that, e.g., a circle with radius 140.1 doesn't necessarily have an odd center, as it would if the circle's bounds were solely determined by rounding the circle's width and height in some way).

Limitation: for ovals, there's no option, for instance, to force an even-centered width and an odd-centered height.

Next, by default, the check for whether a block is within the circle occurs at its center. I added options to perform checks at the corners of the blocks closest or furthest from the center of the circle. Maybe this is useful for strictly including everything that's at all within the circle... but it works best for even-centered circles, due to the below issue.

Limitation: the part of the block closest to the center of the circle might be the center or an edge, not a corner. In particular, this occurs if the width or height is odd and the block is on one (or both) of the axes. In the 1x1 case (radius 0.5), this is particularly noticeable; all four corners of the central block are distance `sqrt(2)/2` away (which is greater than 0.5) from the circle's center, while the block's center is, well, distance 0 away.