### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Node.js CI
+permissions:
+  contents: read
 
 on: [ push, pull_request ]
 


### PR DESCRIPTION
Potential fix for [https://github.com/donatj/Circle-Generator/security/code-scanning/1](https://github.com/donatj/Circle-Generator/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow to explicitly set the minimum required permissions for the GITHUB_TOKEN. Since the workflow only checks out code and builds it, it only needs read access to repository contents. The best way to do this is to add `permissions: contents: read` at the top level of the workflow (just after the `name` field and before `on`). This ensures all jobs in the workflow inherit these minimal permissions unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
